### PR TITLE
Adaptation des tests unitaires pour des raisons de performances

### DIFF
--- a/src/test/java/com/mowitnow/tondeuse/domain/services/GestionPelouseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/GestionPelouseTest.java
@@ -1,11 +1,20 @@
 package com.mowitnow.tondeuse.domain.services;
 
-import com.mowitnow.tondeuse.domain.model.*;
+import com.mowitnow.tondeuse.domain.model.Commande;
+import com.mowitnow.tondeuse.domain.model.Direction;
+import com.mowitnow.tondeuse.domain.model.Pelouse;
+import com.mowitnow.tondeuse.domain.model.Position;
+import com.mowitnow.tondeuse.domain.model.Tondeuse;
+import com.mowitnow.tondeuse.domain.model.TondeuseCommandes;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionPelouseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionTondeuseCommandeImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCommandesTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLignePelouseImpl;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -21,12 +30,18 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @since 0.0.1-SNAPSHOT
  * Description : Classe de test regroupant les tests de service {@link GestionPelouse}
  */
-@SpringBootTest
 class GestionPelouseTest
 {
-    @Autowired
-    @Qualifier("gestionpelouse")
-    private GestionPelouse gestionpelouse;
+    private static GestionPelouse gestionpelouse;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        // Créer une liste des services de mapping
+        var parseLigneServices = Arrays.asList(new ParseurLignePelouseImpl(), new ParseurLigneCoordonneesTondeuseImpl(), new ParseurLigneCommandesTondeuseImpl());
+        gestionpelouse = new GestionPelouseImpl(parseLigneServices, new GestionTondeuseImpl(new GestionTondeuseCommandeImpl()));
+    }
+
 
     @Test
     void intialiser_pelouse_a_partir_dun_fichier() throws FileNotFoundException {

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/GestionTondeuseCommandeTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/GestionTondeuseCommandeTest.java
@@ -5,6 +5,8 @@ import com.mowitnow.tondeuse.domain.model.Direction;
 import com.mowitnow.tondeuse.domain.model.Position;
 import com.mowitnow.tondeuse.domain.model.Tondeuse;
 import com.mowitnow.tondeuse.domain.model.TondeuseCommandes;
+import com.mowitnow.tondeuse.domain.services.implementation.*;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,11 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 0.0.1-SNAPSHOT
  * Description : Classe de test regroupant les tests de service {@link GestionTondeuseCommande}
  */
-@SpringBootTest
 class GestionTondeuseCommandeTest {
 
-    @Autowired
-    private GestionTondeuseCommande gestionTondeuseCommande;
+    private static GestionTondeuseCommande gestionTondeuseCommande;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        // Créer une liste des services de mapping
+        gestionTondeuseCommande = new GestionTondeuseCommandeImpl();
+    }
 
     @Test
     void pivoter_tondeuse_a_gauche()

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCommandesTondeuseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCommandesTondeuseTest.java
@@ -5,12 +5,11 @@ import com.mowitnow.tondeuse.domain.constantes.TestConstantes;
 import com.mowitnow.tondeuse.domain.exception.ParseLigneException;
 import com.mowitnow.tondeuse.domain.model.Commande;
 import com.mowitnow.tondeuse.domain.model.TondeuseCommandes;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCommandesTondeuseImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 
@@ -22,12 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 0.0.1-SNAPSHOT
  * Description : Classe de test regroupant les tests de service {@link com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCommandesTondeuseImpl}
  */
-@SpringBootTest
 class ParseurLigneCommandesTondeuseTest
 {
-    @Autowired
-    @Qualifier("parseurlignecommandestondeuse")
-    private ParseurLigne parseurlignecommandestondeuse;
+    private static ParseurLigne parseurlignecommandestondeuse;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        parseurlignecommandestondeuse = new ParseurLigneCommandesTondeuseImpl();
+    }
 
     @Test
     void lecture_ligne_des_commandes_de_tondeuse_valide()

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCoordonneesTondeuseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCoordonneesTondeuseTest.java
@@ -6,25 +6,28 @@ import com.mowitnow.tondeuse.domain.exception.ParseLigneException;
 import com.mowitnow.tondeuse.domain.model.Direction;
 import com.mowitnow.tondeuse.domain.model.Position;
 import com.mowitnow.tondeuse.domain.model.Tondeuse;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author berrami badr
  * @since 0.0.1-SNAPSHOT
  * Description : Classe de test regroupant les tests de service {@link com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl}
  */
-@SpringBootTest
 class ParseurLigneCoordonneesTondeuseTest
 {
-    @Autowired
-    @Qualifier("parseurlignecoordonneestondeuse")
-    private ParseurLigne parseurlignecoordonneestondeuse;
+    private static ParseurLigne parseurlignecoordonneestondeuse;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        parseurlignecoordonneestondeuse = new ParseurLigneCoordonneesTondeuseImpl();
+    }
 
 
     @Test

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLignePelouseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLignePelouseTest.java
@@ -5,7 +5,10 @@ import com.mowitnow.tondeuse.domain.constantes.TestConstantes;
 import com.mowitnow.tondeuse.domain.exception.ParseLigneException;
 import com.mowitnow.tondeuse.domain.model.Pelouse;
 import com.mowitnow.tondeuse.domain.model.Position;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLignePelouseImpl;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -19,12 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 0.0.1-SNAPSHOT
  * Description : Classe de test regroupant les tests de service {@link com.mowitnow.tondeuse.domain.services.implementation.ParseurLignePelouseImpl}
  */
-@SpringBootTest
 class ParseurLignePelouseTest
 {
-    @Autowired
-    @Qualifier("parseurlignepelouse")
-    private ParseurLigne parseurlignepelouse;
+    private static ParseurLigne parseurlignepelouse;
+
+    @BeforeAll
+    public static void setUp()
+    {
+        parseurlignepelouse = new ParseurLignePelouseImpl();
+    }
 
     @Test
     void lecture_ligne_des_coordonnees_de_pelouse_valide()


### PR DESCRIPTION
Supprimer l'annotation @SpringBootTest dans certains Classes de tests, car elle les rend très lents.