### PR TITLE
Modification des noms de méthodes et variables en camelCase

### DIFF
--- a/src/main/java/com/mowitnow/tondeuse/application/controlleurs/TondeusesController.java
+++ b/src/main/java/com/mowitnow/tondeuse/application/controlleurs/TondeusesController.java
@@ -33,11 +33,11 @@ import java.nio.charset.StandardCharsets;
 public class TondeusesController
 {
 
-    private GestionPelouse gestionpelouse;
+    private GestionPelouse gestionPelouse;
 
     public TondeusesController(GestionPelouse gestionPelouse)
     {
-        this.gestionpelouse = gestionPelouse;
+        this.gestionPelouse = gestionPelouse;
     }
 
     /**
@@ -55,7 +55,7 @@ public class TondeusesController
         {
             throw new FichierVideException("Fichier des coordonnees en entré est vide");
         }
-        var pelouse = gestionpelouse.intialiserEtLancerTendeuse(new BufferedReader(
+        var pelouse = gestionPelouse.intialiserEtLancerTendeuse(new BufferedReader(
                 new InputStreamReader(fichier.getInputStream(), StandardCharsets.UTF_8)));
         model.addAttribute("coordonnees", pelouse.toString());
         return "detaildetondeuses";

--- a/src/main/java/com/mowitnow/tondeuse/domain/model/Pelouse.java
+++ b/src/main/java/com/mowitnow/tondeuse/domain/model/Pelouse.java
@@ -1,6 +1,9 @@
 package com.mowitnow.tondeuse.domain.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;

--- a/src/main/java/com/mowitnow/tondeuse/domain/model/Position.java
+++ b/src/main/java/com/mowitnow/tondeuse/domain/model/Position.java
@@ -1,6 +1,9 @@
 package com.mowitnow.tondeuse.domain.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;

--- a/src/main/java/com/mowitnow/tondeuse/domain/model/Tondeuse.java
+++ b/src/main/java/com/mowitnow/tondeuse/domain/model/Tondeuse.java
@@ -1,6 +1,9 @@
 package com.mowitnow.tondeuse.domain.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;

--- a/src/main/java/com/mowitnow/tondeuse/domain/model/TondeuseCommandes.java
+++ b/src/main/java/com/mowitnow/tondeuse/domain/model/TondeuseCommandes.java
@@ -1,6 +1,9 @@
 package com.mowitnow.tondeuse.domain.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;

--- a/src/main/java/com/mowitnow/tondeuse/infrastructure/configuration/ServiceConfiguration.java
+++ b/src/main/java/com/mowitnow/tondeuse/infrastructure/configuration/ServiceConfiguration.java
@@ -4,7 +4,12 @@ import com.mowitnow.tondeuse.domain.services.GestionPelouse;
 import com.mowitnow.tondeuse.domain.services.GestionTondeuse;
 import com.mowitnow.tondeuse.domain.services.GestionTondeuseCommande;
 import com.mowitnow.tondeuse.domain.services.ParseurLigne;
-import com.mowitnow.tondeuse.domain.services.implementation.*;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionPelouseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionTondeuseCommandeImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.GestionTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCommandesTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl;
+import com.mowitnow.tondeuse.domain.services.implementation.ParseurLignePelouseImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,37 +26,37 @@ import java.util.List;
 public class ServiceConfiguration {
 
     @Bean
-    public ParseurLigne parseurlignecommandestondeuse()
+    public ParseurLigne parseurLigneCommandesTondeuse()
     {
         return new ParseurLigneCommandesTondeuseImpl();
     }
 
     @Bean
-    public ParseurLigne parseurlignecoordonneestondeuse()
+    public ParseurLigne parseurLigneCoordonneesTondeuse()
     {
         return new ParseurLigneCoordonneesTondeuseImpl();
     }
 
     @Bean
-    public ParseurLigne parseurlignepelouse()
+    public ParseurLigne parseurLignePelouse()
     {
         return new ParseurLignePelouseImpl();
     }
 
     @Bean
-    public GestionPelouse gestionpelouse(@Autowired List<ParseurLigne> parseurLignes, @Autowired GestionTondeuse gestionTondeuse)
+    public GestionPelouse gestionPelouse(@Autowired List<ParseurLigne> parseurLignes, @Autowired GestionTondeuse gestionTondeuse)
     {
         return new GestionPelouseImpl(parseurLignes, gestionTondeuse);
     }
 
     @Bean
-    public GestionTondeuse gestiontondeuse(@Autowired GestionTondeuseCommande gestionTondeuseCommande)
+    public GestionTondeuse gestionTondeuse(@Autowired GestionTondeuseCommande gestionTondeuseCommande)
     {
         return new GestionTondeuseImpl(gestionTondeuseCommande);
     }
 
     @Bean
-    public GestionTondeuseCommande gestiontondeusecommande()
+    public GestionTondeuseCommande gestionTondeuseCommande()
     {
         return new GestionTondeuseCommandeImpl();
     }

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/GestionPelouseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/GestionPelouseTest.java
@@ -32,14 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 class GestionPelouseTest
 {
-    private static GestionPelouse gestionpelouse;
+    private static GestionPelouse gestionPelouse;
 
     @BeforeAll
     public static void setUp()
     {
         // Créer une liste des services de mapping
         var parseLigneServices = Arrays.asList(new ParseurLignePelouseImpl(), new ParseurLigneCoordonneesTondeuseImpl(), new ParseurLigneCommandesTondeuseImpl());
-        gestionpelouse = new GestionPelouseImpl(parseLigneServices, new GestionTondeuseImpl(new GestionTondeuseCommandeImpl()));
+        gestionPelouse = new GestionPelouseImpl(parseLigneServices, new GestionTondeuseImpl(new GestionTondeuseCommandeImpl()));
     }
 
 
@@ -54,7 +54,7 @@ class GestionPelouseTest
         var positionInitialeTendeuse2 = new Position(3, 3);
         var pelouse = creerUnPelouse(positionInitialeTendeuse1, positionInitialeTendeuse2);
         // Act
-        var pelouseObtenu = gestionpelouse.initialiserPelouse(fichierEntree);
+        var pelouseObtenu = gestionPelouse.initialiserPelouse(fichierEntree);
         // Assert
         Assertions.assertEquals(pelouse, pelouseObtenu);
     }
@@ -66,7 +66,7 @@ class GestionPelouseTest
         // - Déclarer un fichier vide
         var fichierVide = recupererFichierEntree("files/fichiervide.txt");
         // Act
-        var pelouseNull = gestionpelouse.initialiserPelouse(fichierVide);
+        var pelouseNull = gestionPelouse.initialiserPelouse(fichierVide);
         // Assert
         assertNull(pelouseNull);
     }
@@ -82,7 +82,7 @@ class GestionPelouseTest
         var positionInitialeTendeuse2 = new Position(5, 1);
         var pelouse = creerUnPelouse(positionInitialeTendeuse1, positionInitialeTendeuse2);
         // Act
-        var pelouseObtenu = gestionpelouse.intialiserEtLancerTendeuse(fichierEntree);
+        var pelouseObtenu = gestionPelouse.intialiserEtLancerTendeuse(fichierEntree);
         // Assert
         Assertions.assertEquals(pelouse, pelouseObtenu);
     }

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCommandesTondeuseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCommandesTondeuseTest.java
@@ -23,12 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ParseurLigneCommandesTondeuseTest
 {
-    private static ParseurLigne parseurlignecommandestondeuse;
+    private static ParseurLigne parseurLigneCommandesTondeuse;
 
     @BeforeAll
     public static void setUp()
     {
-        parseurlignecommandestondeuse = new ParseurLigneCommandesTondeuseImpl();
+        parseurLigneCommandesTondeuse = new ParseurLigneCommandesTondeuseImpl();
     }
 
     @Test
@@ -49,7 +49,7 @@ class ParseurLigneCommandesTondeuseTest
         commandes.add(Commande.AVANCER);
         tondeuseCommandesAttendu.setCommandes(commandes);
         // Act
-        var tondeuseCommandesObtenu = (TondeuseCommandes) parseurlignecommandestondeuse.lireLigneDeFichier(tondeuseCoordonnees);
+        var tondeuseCommandesObtenu = (TondeuseCommandes) parseurLigneCommandesTondeuse.lireLigneDeFichier(tondeuseCoordonnees);
         // Assert
         Assertions.assertEquals(tondeuseCommandesAttendu, tondeuseCommandesObtenu);
     }
@@ -62,7 +62,7 @@ class ParseurLigneCommandesTondeuseTest
         var  tondeuseCoordonneesVide = StringUtils.EMPTY;
         // Act
         var parseLigneException = assertThrows(ParseLigneException.class,
-                () -> parseurlignecommandestondeuse.lireLigneDeFichier(tondeuseCoordonneesVide),
+                () -> parseurLigneCommandesTondeuse.lireLigneDeFichier(tondeuseCoordonneesVide),
                 TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         assertEquals(ErreursMessages.LIGNE_TONDEUSE_COMMANDES_VIDE_EXCEPTION_MESSAGE, parseLigneException.getMessage());
     }
@@ -75,7 +75,7 @@ class ParseurLigneCommandesTondeuseTest
         var  tondeuseCoordonneesIncorrecte = "GAGAF";
         // Act
         var parseLigneException = assertThrows(ParseLigneException.class,
-                () -> parseurlignecommandestondeuse.lireLigneDeFichier(tondeuseCoordonneesIncorrecte),
+                () -> parseurLigneCommandesTondeuse.lireLigneDeFichier(tondeuseCoordonneesIncorrecte),
                 TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         assertEquals(ErreursMessages.LIGNE_TONDEUSE_COMMANDES_EXCEPTION_MESSAGE, parseLigneException.getMessage());
     }

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCoordonneesTondeuseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLigneCoordonneesTondeuseTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ParseurLigneCoordonneesTondeuseTest
 {
-    private static ParseurLigne parseurlignecoordonneestondeuse;
+    private static ParseurLigne parseurLigneCoordonneesTondeuse;
 
     @BeforeAll
     public static void setUp()
     {
-        parseurlignecoordonneestondeuse = new ParseurLigneCoordonneesTondeuseImpl();
+        parseurLigneCoordonneesTondeuse = new ParseurLigneCoordonneesTondeuseImpl();
     }
 
 
@@ -44,7 +44,7 @@ class ParseurLigneCoordonneesTondeuseTest
         tondeuseAttendu.setPosition(position);
         tondeuseAttendu.setDirection(Direction.NORTH);
         // Act
-        var tondeuseObtenu = parseurlignecoordonneestondeuse.lireLigneDeFichier(tondeuseCoordonnees);
+        var tondeuseObtenu = parseurLigneCoordonneesTondeuse.lireLigneDeFichier(tondeuseCoordonnees);
         // Arrange
         assertEquals(tondeuseAttendu, tondeuseObtenu);
     }
@@ -57,7 +57,7 @@ class ParseurLigneCoordonneesTondeuseTest
         var coordonneesTondeuseVide = StringUtils.EMPTY;
         // Act
         var parseLigneException = assertThrows(ParseLigneException.class,
-                () -> parseurlignecoordonneestondeuse.lireLigneDeFichier(coordonneesTondeuseVide),
+                () -> parseurLigneCoordonneesTondeuse.lireLigneDeFichier(coordonneesTondeuseVide),
                 TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         assertEquals(ErreursMessages.LIGNE_TONDEUSE_COORDONNEES_VIDE_EXCEPTION_MESSAGE, parseLigneException.getMessage());
     }
@@ -70,7 +70,7 @@ class ParseurLigneCoordonneesTondeuseTest
         var coordonneesTondeuseIncorrecte = "1 3 F";
         // Act
         var parseLigneException = assertThrows(ParseLigneException.class,
-                () -> parseurlignecoordonneestondeuse.lireLigneDeFichier(coordonneesTondeuseIncorrecte),
+                () -> parseurLigneCoordonneesTondeuse.lireLigneDeFichier(coordonneesTondeuseIncorrecte),
                 TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         assertEquals(ErreursMessages.LIGNE_TONDEUSE_COORDONNEES_EXCEPTION_MESSAGE, parseLigneException.getMessage());
     }

--- a/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLignePelouseTest.java
+++ b/src/test/java/com/mowitnow/tondeuse/domain/services/ParseurLignePelouseTest.java
@@ -5,14 +5,10 @@ import com.mowitnow.tondeuse.domain.constantes.TestConstantes;
 import com.mowitnow.tondeuse.domain.exception.ParseLigneException;
 import com.mowitnow.tondeuse.domain.model.Pelouse;
 import com.mowitnow.tondeuse.domain.model.Position;
-import com.mowitnow.tondeuse.domain.services.implementation.ParseurLigneCoordonneesTondeuseImpl;
 import com.mowitnow.tondeuse.domain.services.implementation.ParseurLignePelouseImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,12 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class ParseurLignePelouseTest
 {
-    private static ParseurLigne parseurlignepelouse;
+    private static ParseurLigne parseurLignePelouse;
 
     @BeforeAll
     public static void setUp()
     {
-        parseurlignepelouse = new ParseurLignePelouseImpl();
+        parseurLignePelouse = new ParseurLignePelouseImpl();
     }
 
     @Test
@@ -45,7 +41,7 @@ class ParseurLignePelouseTest
         var pelouse = new Pelouse(positionSuperieure, null);
         // Act
         // - Appeller le service de parsing des coordonnées de pelouse
-        var pelouseObtenu = parseurlignepelouse.lireLigneDeFichier(coordonneesPelouse);
+        var pelouseObtenu = parseurLignePelouse.lireLigneDeFichier(coordonneesPelouse);
         // Arrange
         assertEquals(pelouse, pelouseObtenu);
     }
@@ -57,7 +53,7 @@ class ParseurLignePelouseTest
         // - Ligne de coordonnées vide
         var coordonneesPelouseVide = StringUtils.EMPTY;
         // Act
-        var parseException = assertThrows(ParseLigneException.class, () -> parseurlignepelouse.lireLigneDeFichier(coordonneesPelouseVide), TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
+        var parseException = assertThrows(ParseLigneException.class, () -> parseurLignePelouse.lireLigneDeFichier(coordonneesPelouseVide), TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         // Arrange
         assertEquals(ErreursMessages.LIGNE_PELOUSE_COORDONNEES_VIDE_EXCEPTION_MESSAGE, parseException.getMessage());
     }
@@ -69,7 +65,7 @@ class ParseurLignePelouseTest
         // - Ligne de coordonnées incorrecte
         var coordonneesPelouseIncorrectees = "1 2 3";
         // Act
-        var parseException = assertThrows(ParseLigneException.class, () -> parseurlignepelouse.lireLigneDeFichier(coordonneesPelouseIncorrectees), TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
+        var parseException = assertThrows(ParseLigneException.class, () -> parseurLignePelouse.lireLigneDeFichier(coordonneesPelouseIncorrectees), TestConstantes.MESSAGE_APPEL_METHODE_LIRE_LIGNE_DE_FICHIER);
         // Arrange
         assertEquals(ErreursMessages.LIGNE_PELOUSE_COORDONNEES_EXCEPTION_MESSAGE, parseException.getMessage());
     }


### PR DESCRIPTION
Corriger les noms de certaines méthodes et variables. Ecrire en camelCase conformément aux règles de Clean code